### PR TITLE
Remove AbortIncompleteMultipartUploads tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 ![Latest GitHub Release](https://img.shields.io/github/v/release/byu-oit/terraform-aws-codebuild-ci?sort=semver)
 
 # Terraform AWS Codebuild CI for Github
+
 Build Codebuild CI for Github
 
 ## Usage
+
 ```hcl
 module "terraform-aws-codebuild-ci" {
   source                        = "github.com/byu-oit/terraform-aws-codebuild-ci?ref=v0.0.4"
   name                          = "ci-name"
   github_repo                   = "https://github.com/byu-oit/fakerepo"
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
-  buildspec                     = "cb-buildspec.yml"
   source_version                = "master"
 }
 ```
 
 ## Requirements
+
 * Terraform version 0.12.16 or greater
 
 ## Inputs
+
 | Name | Type  | Description | Default |
 | --- | --- | --- | --- |
 |name | string | Name of CI| |
@@ -27,8 +30,19 @@ module "terraform-aws-codebuild-ci" {
 |buildspec | string| The name of the buildspec file or the buildspec string | cb-buildspec.yml |
 |build_env_variables | map(string)| | {}|
 |tags | map(string)| |{} |
+|source_version | string | Base branch to trigger CodeBuild's. | |
+|webhook_filters | list(object) | [{type = "EVENT", pattern = "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED", exclude_matched_pattern = false}] |
+
+### webhook_filters object
+
+| Key | Values |
+| --- | --- |
+|type | EVENT, BASE_REF, HEAD_REF, ACTOR_ACCOUNT_ID, FILE_PATH |
+|pattern | PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED, PULL_REQUEST_MERGED |
+|exclude_matched_pattern | true, false |
 
 ## Outputs
+
 | Name | Type | Description |
 | ---  | ---  | --- |
-| | | |
+| codebuild_project | [object](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#argument-reference) | AWS CodeBuild project. |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module "terraform-aws-codebuild-ci" {
 ## Requirements
 
 * Terraform version 0.12.16 or greater
+* AWS provider version 2.42 or greater
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build Codebuild CI for Github
 
 ```hcl
 module "terraform-aws-codebuild-ci" {
-  source                        = "github.com/byu-oit/terraform-aws-codebuild-ci?ref=v0.0.4"
+  source                        = "github.com/byu-oit/terraform-aws-codebuild-ci?ref=v0.0.5"
   name                          = "ci-name"
   github_repo                   = "https://github.com/byu-oit/fakerepo"
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ resource "aws_s3_bucket" "ci_cache" {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 10
     id                                     = "AutoAbortFailedMultipartUpload"
-    tags                                   = var.tags
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "codebuild_project" {
+  value = aws_codebuild_project.ci-codebuild-project
+}


### PR DESCRIPTION
Per [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html#lc-expire-mpu), "When specifying the AbortIncompleteMultipartUpload Lifecycle action, the rule cannot specify a tag-based filter." I have removed the tags for that lifecycle policy to prevent the following error from Terraform: `Error: Error putting S3 lifecycle: InvalidRequest: AbortIncompleteMultipartUpload cannot be specified with Tags.`

This PR also updates documentation.