### PR TITLE
Remove git_submodule_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build Codebuild CI for Github
 
 ```hcl
 module "terraform-aws-codebuild-ci" {
-  source                        = "github.com/byu-oit/terraform-aws-codebuild-ci?ref=v0.0.5"
+  source                        = "github.com/byu-oit/terraform-aws-codebuild-ci?ref=v0.0.6"
   name                          = "ci-name"
   github_repo                   = "https://github.com/byu-oit/fakerepo"
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn

--- a/main.tf
+++ b/main.tf
@@ -131,10 +131,6 @@ resource "aws_codebuild_project" "ci-codebuild-project" {
     type      = "GITHUB"
     buildspec = var.buildspec
     location  = var.github_repo
-    //TODO: Submodules?
-    git_submodules_config {
-      fetch_submodules = true
-    }
     git_clone_depth     = 1
     report_build_status = true
     insecure_ssl        = false


### PR DESCRIPTION
The `git_submodule_config` only works when the source is CODECOMMIT (see [Terraform resource documentation](https://www.terraform.io/docs/providers/aws/r/codebuild_project.html). Since the source is GITHUB, we can't use it. If we do, Terraform will always try to apply that property to the resource, but never succeed.